### PR TITLE
Fix "null" user issue

### DIFF
--- a/src/utils/auth.js
+++ b/src/utils/auth.js
@@ -2,10 +2,13 @@ const isBrowser = typeof window !== `undefined`
 
 export const setUser = user => (window.localStorage.gatsbyUser = JSON.stringify(user))
 
-const getUser = () =>
-  window.localStorage.gatsbyUser
-    ? JSON.parse(window.localStorage.gatsbyUser)
-    : {}
+const getUser = () => {
+  if (window.localStorage.gatsbyUser) {
+    let user = JSON.parse(window.localStorage.gatsbyUser)
+    return user ? user : {}
+  }
+  return {}
+}
 
 export const isLoggedIn = () => {
   if (!isBrowser) return false


### PR DESCRIPTION
When not authenticated, LocalStorage can receive a user value of "null". When this value is parsed from JSON it ends up breaking the return line of the `isLoggedIn` method.

Adding an additional check to `getUser` to ensure that if the parsed value is falsy it will return an empty object