### PR TITLE
correct/clarify installation steps/instructions.

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ gatsby new gatsby-amplify-auth https://github.com/dabit3/gatsby-auth-starter-aws
 cd gatsby-amplify-auth
 ```
 
-3. Change into the new directory
+3. Install dependencies
 
 ```sh
 yarn


### PR DESCRIPTION
Step 3 seemed to describe what Step 2 had already been used to achieve; I'm guessing a typo.